### PR TITLE
[documentation]Fix typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-caver-py
-=================
+# caver-py
 
 caver-py is a Python API library that allows developers to interact with a
 Klaytn node using a HTTP or Websocket connection.
 
-Sample Projects
-=================
+# Sample Projects
 
 The BApp (Blockchain Application) Development sample projects using caver-js are the following:
 
-* [Count BApp](https://docs.klaytn.com/bapp/tutorials/count-bapp)
-* [Klaystagram](https://docs.klaytn.com/bapp/tutorials/klaystagram)
+- [Count BApp](https://docs.klaytn.com/bapp/tutorials/count-bapp)
+- [Klaystagram](https://docs.klaytn.com/bapp/tutorials/klaystagram)
 
-Github Repository
-=================
+# Github Repository
 
-* [caver-py](https://github.com/SKKone-klaytn/caver-py)
+- [caver-py](https://github.com/SKKone-klaytn/caver-py)
 
-Related Projects
-=================
+# Related Projects
+
 [caver-java](https://github.com/klaytn/caver-java) for Java
-[caver-java](https://github.com/klaytn/caver-js) for Javascript
+[caver-js](https://github.com/klaytn/caver-js) for Javascript


### PR DESCRIPTION
caver-java for Javascript 에서 caver-js for Javascript  로 변경 #